### PR TITLE
Add support for board FIT configuration

### DIFF
--- a/include/configs/evb_ast2700.h
+++ b/include/configs/evb_ast2700.h
@@ -16,14 +16,14 @@
 
 #define CFG_EXTRA_ENV_SETTINGS \
 	"bootspi=fdt addr ${fdtspiaddr} && fdt header get fitsize totalsize && " \
-	"cp.b ${fdtspiaddr} ${loadaddr} ${fitsize} && bootm; " \
+	"cp.b ${fdtspiaddr} ${loadaddr} ${fitsize} && bootm ${loadaddr}${board_conf}; " \
 	"echo Error loading kernel FIT image\0" \
 	"loadaddr=" STR(CONFIG_SYS_LOAD_ADDR) "\0"	\
 	"bootside=a\0"	\
 	"rootfs=rofs-a\0"	\
 	"setmmcargs=setenv bootargs ${bootargs} rootwait root=PARTLABEL=${rootfs}\0"	\
-	"boota=setenv bootpart 2; setenv rootfs rofs-a; run setmmcargs; ext4load mmc 0:${bootpart} ${loadaddr} fitImage && bootm; echo Error loading kernel FIT image\0"	\
-	"bootb=setenv bootpart 3; setenv rootfs rofs-b; run setmmcargs; ext4load mmc 0:${bootpart} ${loadaddr} fitImage && bootm; echo Error loading kernel FIT image\0"	\
+	"boota=setenv bootpart 2; setenv rootfs rofs-a; run setmmcargs; ext4load mmc 0:${bootpart} ${loadaddr} fitImage && bootm ${loadaddr}${board_conf}; echo Error loading kernel FIT image\0"	\
+	"bootb=setenv bootpart 3; setenv rootfs rofs-b; run setmmcargs; ext4load mmc 0:${bootpart} ${loadaddr} fitImage && bootm ${loadaddr}${board_conf}; echo Error loading kernel FIT image\0"	\
 	"bootmmc=if test \"${bootside}\" = \"b\"; then run bootb; run boota; else run boota; run bootb; fi\0"	\
 	"verify=yes\0"	\
 	""


### PR DESCRIPTION
adds env variable to support multi-dtb fitImage
if env variable is not set, boot to first dtb in fitImage

