### PR TITLE
board: Add power-on reset env variable

### DIFF
--- a/arch/arm/mach-aspeed/ast2700/cpu-info.c
+++ b/arch/arm/mach-aspeed/ast2700/cpu-info.c
@@ -84,9 +84,14 @@ void ast2700_print_wdtrst_info(void)
 #define SYS_EXTRST		BIT(1)
 #define SYS_SRST		BIT(0)
 
+/* One of Sys Scratch reg available for SW use 
+   save CPU reset info to create reset cause env variable */
+#define ASPEED_SYS_SCRATCH_7FC 0x12C027FC
+
 void ast2700_print_sysrst_info(void)
 {
 	u32 sys_rst = readl(ASPEED_CPU_RESET_LOG1);
+	writel(sys_rst, ASPEED_SYS_SCRATCH_7FC);
 
 	if (sys_rst & SYS_SRST) {
 		printf("RST: Power On\n");

--- a/arch/arm/mach-aspeed/ast2700/cpu-info.c
+++ b/arch/arm/mach-aspeed/ast2700/cpu-info.c
@@ -47,9 +47,9 @@ void ast2700_print_soc_id(void)
 #define SYS_SRST		BIT(0)
 
 #define WDT_RST_BIT_MASK(s)	(GENMASK(3, 0) << (s))
-#define BIT_WDT_SOC(s)		(BIT(0) << (s))
+#define BIT_WDT_SOC(s)		(BIT(2) << (s))
 #define BIT_WDT_FULL(s)		(BIT(1) << (s))
-#define BIT_WDT_ARM(s)		(BIT(2) << (s))
+#define BIT_WDT_ARM(s)		(BIT(0) << (s))
 #define BIT_WDT_SW(s)		(BIT(3) << (s))
 
 void ast2700_print_wdtrst_info(void)


### PR DESCRIPTION
Adds support to read syscontrol reset status register to check if BMC booting after AC power on. Exports the Boolean value in u-boot env var, so that BMC can read DIMM SPD.
