### PR TITLE
board:a1 Add eSPI GPIO configuration

### DIFF
--- a/board/aspeed/evb_ast2700/evb_ast2700.c
+++ b/board/aspeed/evb_ast2700/evb_ast2700.c
@@ -376,7 +376,7 @@ int misc_init_r(void)
 	}
 	/* set power-on reset variable */
 	update_por_env();
-
+        // set espi strap to low and train ltpi with max of 10 sec
         run_command("mw 14c02404 0", 0);
         run_command("gpio clear 10", 0);
         run_command("ltpi -T 10000000",0);

--- a/board/aspeed/evb_ast2700/evb_ast2700.c
+++ b/board/aspeed/evb_ast2700/evb_ast2700.c
@@ -377,6 +377,10 @@ int misc_init_r(void)
 	/* set power-on reset variable */
 	update_por_env();
 
+        run_command("mw 14c02404 0", 0);
+        run_command("gpio clear 10", 0);
+        run_command("ltpi -T 10000000",0);
+
 	return 0;
 err:
 	printf("EEPROM i2c error in %s\n", __func__);


### PR DESCRIPTION
Set the eSPI GPIO configuration to enable receiving POST Codes.
 - set GPIOB2 to low.
 - set direction to output
 - configure LTPI Timeout
