### PR TITLE
Ltpi  and safs 

### DIFF
--- a/board/aspeed/evb_ast2700/evb_ast2700.c
+++ b/board/aspeed/evb_ast2700/evb_ast2700.c
@@ -48,7 +48,16 @@
 
 /* Sys Scratch reg that holds sys_rst info, refer cpu-info.c */
 #define ASPEED_SYS_SCRATCH_7FC 0x12C027FC
-#define SYS_SRST		BIT(0)
+#define SYS_SRST               BIT(0)
+
+/* LTPI */
+#define LTPI_TRAIN_RETRY       (10)
+// 100ms for LTPI spec 1.1
+#define ADVRT_TIMEOUT_US_1_1   "100000"
+// 1ms for LTPI spec 1.0
+#define ADVRT_TIMEOUT_US_1_0   "1000"
+// 3x advt timeout for FPGA to move to LDFA state
+#define OP_TIMEOUT_US          "300000"
 
 /* SP7 HPM boards */
 #define MARLEY_1        0x79
@@ -325,6 +334,42 @@ int set_board_info(const u8* scm_eeprom_buf, const u8* hpm_eeprom_buf)
 	return 0;
 }
 
+void configure_safs_spi_mux()
+{
+	printf("configuring gpios for eDAF ...\n");
+	/* remote P0 BIOS SPI */
+	run_command("gpio set 169", 0); //GPIO V1
+	run_command("gpio set 170", 0); //GPIO V2
+	printf("configuring gpios for eDAF ...Done\n");
+}
+
+void train_ltpi(int retry)
+{
+	int i=0;
+	// set espi GPIO strap to low
+	// this reconfigures pin from SCM_GPO to GPIO mode.
+	run_command("mw 14c02404 55000055", 0);
+	run_command("gpio clear 10", 0);
+
+	/* start LTPI with operational and advertise timeouts */
+	if(run_command("ltpi -T " OP_TIMEOUT_US " -t " ADVRT_TIMEOUT_US_1_1, 0) != 0)
+	{
+		for (i=0; i<retry; i++)
+		{
+			if(run_command("ltpi -T " OP_TIMEOUT_US " -t "ADVRT_TIMEOUT_US_1_1 ,0) == 0)
+			{
+				printf("LTPI link configured, proceeding to boot...\n");
+				break;
+			}
+			else
+			{
+				printf("Retrying Link training...\n");
+			}
+		}
+		if (i >= retry)
+			printf("LTPI failed to train, collect register dump!!!\n");
+	}
+}
 void update_por_env(void)
 {
 	const char *s;
@@ -401,8 +446,15 @@ int misc_init_r(void)
 	{
 		printf("Loading %s\n", env_get(ENV_BOARD_FIT_CONF));
 	}
+
 	/* set power-on reset variable */
 	update_por_env();
+
+	/* configure spi mux for safs */
+	configure_safs_spi_mux();
+
+	/* enable ltpi strap and train link */
+	train_ltpi(LTPI_TRAIN_RETRY);
 
 	return 0;
 err:

--- a/board/aspeed/evb_ast2700/evb_ast2700.c
+++ b/board/aspeed/evb_ast2700/evb_ast2700.c
@@ -403,10 +403,6 @@ int misc_init_r(void)
 	}
 	/* set power-on reset variable */
 	update_por_env();
-        // set espi strap to low and train ltpi with max of 10 sec
-        run_command("mw 14c02404 0", 0);
-        run_command("gpio clear 10", 0);
-        run_command("ltpi -T 10000000",0);
 
 	return 0;
 err:

--- a/cmd/aspeed/ltpi/ltpi-v2.c
+++ b/cmd/aspeed/ltpi/ltpi-v2.c
@@ -365,7 +365,7 @@ static int ltpi_wait_state_op(struct ltpi_priv *ltpi)
 
 	return ltpi_poll_link_mng_state(ltpi, LTPI_LINK_MNG_ST_OP,
 					LTPI_LINK_MNG_ST_DETECT_ALIGN,
-					ADVERTISE_TIMEOUT_US);
+					ltpi->ad_timeout);
 }
 
 static int ltpi_set_lvds_io_driving(struct ltpi_priv *ltpi, int driving)
@@ -466,6 +466,15 @@ static void ltpi_do_link_training(struct ltpi_priv *ltpi)
 	clrsetbits_le32((void *)ltpi->base + LTPI_LINK_MANAGE_CTRL0,
 			REG_LTPI_RX_LINK_SP_FRM_NUM,
 			FIELD_PREP(REG_LTPI_RX_LINK_SP_FRM_NUM, ltpi->link_speed_frm_rx_cnt));
+
+	/*
+	 * ad_timeout in us = ad_timeout in clock cycles * period of 25MHz
+	 * ad_timeout in clock cycles
+	 * = ad_timeout in us / period of 25MHz
+	 * = (ad_timeout in us * 1000)ns / 40ns = ad_timeout * 25
+	 */
+	writel(ltpi->ad_timeout * 25, (void *)ltpi->base + LTPI_LINK_MANAGE_CTRL1);
+	printf("[%08x] %08x\n", (u32)ltpi->base + LTPI_LINK_MANAGE_CTRL1, readl((void *)ltpi->base + LTPI_LINK_MANAGE_CTRL1));
 
 	/* Set the clock source to the base frequency 25MHz */
 	ltpi_phy_set_clksel(ltpi, REG_LTPI_PLL_25M, false);

--- a/cmd/aspeed/ltpi/ltpi-v2.c
+++ b/cmd/aspeed/ltpi/ltpi-v2.c
@@ -646,6 +646,27 @@ static int ltpi_optimeout_query(struct ltpi_priv *ltpi)
 	return 0;
 }
 
+static void ltpi_dump(struct ltpi_priv *ltpi)
+{
+	int i;
+
+	for (i = 0; i < 0x250; i += 4) {
+		if (i % 16 == 0)
+			printf("\n[%08x] ", (uint32_t)ltpi->base + i);
+
+		printf("%08x ", readl((void *)ltpi->base + i));
+	}
+	printf("\n");
+
+	for (i = 0; i < 0x30; i += 4) {
+		if (i % 16 == 0)
+			printf("\n[%08x] ", (uint32_t)ltpi->top_base + i);
+
+		printf("%08x ", readl((void *)ltpi->top_base + i));
+	}
+	printf("\n");
+}
+
 static void ltpi_scm_init(struct ltpi_priv *ltpi)
 {
 	int ret, target_speed;
@@ -669,7 +690,14 @@ static void ltpi_scm_init(struct ltpi_priv *ltpi)
 			if (ret == LTPI_ERR_NONE)
 				break;
 
-			if (ctrlc() || ltpi_optimeout_query(ltpi)) {
+			if (ctrlc()) {
+				printf("User terminated for waiting PLL set state\n");
+				ltpi_log_exit(ltpi, LTPI_SYND_USER_TERMINATE);
+				goto ltpi_scm_exit;
+			}
+
+			if (ltpi_optimeout_query(ltpi)) {
+				printf("Timeout waiting for PLL set state\n");
 				ltpi_log_exit(ltpi, LTPI_SYND_EXTRST_LINK_TRAINING);
 				goto ltpi_scm_exit;
 			}
@@ -699,7 +727,14 @@ static void ltpi_scm_init(struct ltpi_priv *ltpi)
 		if (readl((void *)ltpi->base + LTPI_LINK_ST) & REG_LTPI_FRM_CRC_ERR)
 			ltpi->bootstage->errno |= LTPI_STATUS_HAS_CRC_ERR;
 
-		if (ctrlc() || ltpi_optimeout_query(ltpi)) {
+		if (ctrlc()) {
+			printf("User terminated for waiting operational state\n");
+			ltpi_log_exit(ltpi, LTPI_SYND_USER_TERMINATE);
+			goto ltpi_scm_exit;
+		}
+
+		if (ltpi_optimeout_query(ltpi)) {
+			printf("Timeout waiting for operational state\n");
 			ltpi_log_exit(ltpi, LTPI_SYND_EXTRST_LINK_CONFIG);
 			goto ltpi_scm_exit;
 		}
@@ -712,11 +747,15 @@ static void ltpi_scm_init(struct ltpi_priv *ltpi)
 			ltpi->phy_speed_cap |= BIT(0);
 
 		ltpi_log_restart(ltpi, LTPI_SYND_WAIT_OP_TO);
+		printf("LTPI restart due to timeout waiting for operational state\n");
+		ltpi_dump(ltpi);
 	} while (1);
 
 	return;
 
 ltpi_scm_exit:
+	printf("Exit LTPI initialization\n");
+	ltpi_dump(ltpi);
 	ltpi_reset(ltpi);
 }
 

--- a/cmd/aspeed/ltpi/ltpi-v2.h
+++ b/cmd/aspeed/ltpi/ltpi-v2.h
@@ -30,6 +30,7 @@
 #define LTPI_SYND_EXTRST_LINK_TRAINING		4	/* EXTRST deasserted during link training */
 #define LTPI_SYND_EXTRST_LINK_CONFIG		5	/* EXTRST deasserted during link configuration */
 #define LTPI_SYND_SOC_RECOVERY			6	/* Exit due to SOC recovery */
+#define LTPI_SYND_USER_TERMINATE		7	/* Exit due to user terminate */
 
 /* LTPI wait state return code */
 #define LTPI_ERR_NONE				0x00

--- a/include/configs/evb_ast2700.h
+++ b/include/configs/evb_ast2700.h
@@ -15,7 +15,7 @@
 #define CFG_SYS_UBOOT_BASE		CONFIG_TEXT_BASE
 
 #define CFG_EXTRA_ENV_SETTINGS \
-	"bootspi=ltpi -T 10000000; fdt addr ${fdtspiaddr} && fdt header get fitsize totalsize && " \
+	"bootspi=fdt addr ${fdtspiaddr} && fdt header get fitsize totalsize && " \
 	"cp.b ${fdtspiaddr} ${loadaddr} ${fitsize} && bootm ${loadaddr}${board_conf}; " \
 	"echo Error loading kernel FIT image\0" \
 	"loadaddr=" STR(CONFIG_SYS_LOAD_ADDR) "\0"	\


### PR DESCRIPTION
Integrate LTPI tool patches from Aspeed
Add ltpi with 100ms advertise timeout and 300ms operational timeout
Add retries for ltpi training
Configure spi mux for remote bios flash to BMC spi path

Tested on congo VRB system
