### PR TITLE
config: Add support for board FIT configuration

### DIFF
--- a/include/configs/evb_ast2700.h
+++ b/include/configs/evb_ast2700.h
@@ -16,7 +16,7 @@
 
 #define CFG_EXTRA_ENV_SETTINGS \
 	"bootspi=fdt addr ${fdtspiaddr} && fdt header get fitsize totalsize && " \
-	"cp.b ${fdtspiaddr} ${loadaddr} ${fitsize} && bootm ${loadaddr}; " \
+	"cp.b ${fdtspiaddr} ${loadaddr} ${fitsize} && bootm ${loadaddr}${board_conf}; " \
 	"echo Error loading kernel FIT image\0" \
 	"loadaddr=" STR(CONFIG_SYS_LOAD_ADDR) "\0"	\
 	"bootside=a\0"	\


### PR DESCRIPTION
adds env variable to support multi-dtb fitImage
for SPI boot target

Tested: Verified on Malawi

