### PR TITLE
Emmc support in Uboot

### DIFF
--- a/arch/arm/dts/ast2700-sp7.dts
+++ b/arch/arm/dts/ast2700-sp7.dts
@@ -187,22 +187,56 @@
 
 &emmc_controller {
 	status = "okay";
-	timing-phase = <0xf0097>;
+	sdhci_hs200; /* enable hs200 */
 };
 
 &emmc {
 	status = "okay";
+	max-frequency = <200000000>;
 };
 
 &sdc {
-	timing-phase = <0x1f0097>;
 	status = "okay";
+	sdhci_hs200; /* enable sdr104 */
+
+	vcc_sdio: vcc-sdio {
+		status = "okay";
+		compatible = "regulator-fixed";
+		gpios = <&gpio0 ASPEED_GPIO(G, 6) GPIO_ACTIVE_HIGH>;
+		regulator-name = "vcc_sdio";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		enable-active-high;
+		regulator-boot-on;
+	};
+
+	vccq_sdio: vccq-sdio {
+		status = "okay";
+		compatible = "regulator-gpio";
+		gpios = <&gpio0 ASPEED_GPIO(G, 7) GPIO_ACTIVE_HIGH>;
+		gpios-states = <1>;
+		states = <1800000 0x0>,
+			 <3300000 0x1>;
+		regulator-name = "vccq_sdio";
+		regulator-type = "voltage";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
 };
 
 &sdhci {
 	status = "okay";
-	sdhci,auto-cmd12;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_sdio_default>;
+	vmmc-supply = <&vcc_sdio>;
+	vqmmc-supply = <&vccq_sdio>;
+	/*
+	 * When running SDR104 mode, it suggests to set driving to 3.
+	 * When running HS mode, it suggests to set driving to 2.
+	 */
 	sdhci-drive-type = <3>;
+	max-frequency = <125000000>;
 };
 
 &i2c0 {

--- a/drivers/mmc/sdhci.c
+++ b/drivers/mmc/sdhci.c
@@ -579,7 +579,7 @@ static void sdhci_set_voltage(struct sdhci_host *host)
 			}
 
 			/* Wait for 5ms */
-			mdelay(5);
+			mdelay(15);
 
 			/* 3.3V regulator output should be stable within 5 ms */
 			if (IS_SD(mmc)) {
@@ -615,7 +615,7 @@ static void sdhci_set_voltage(struct sdhci_host *host)
 			}
 
 			/* Wait for 5 ms */
-			mdelay(5);
+			mdelay(15);
 
 			/* 1.8V regulator output has to be stable within 5 ms */
 			if (IS_SD(mmc)) {


### PR DESCRIPTION
- Add emmc and sdhci to SP7 device tree
- Sync Aspeed patch for sdhci

Tested on Morocco

UT Log:
sp7# mmc info
Device: sdhci@12090100
Manufacturer ID: 15
OEM: 0
Name: 8GTF4R
Bus Speed: 200000000
Mode: HS200 (200MHz)
Rd Block Len: 512
MMC version 5.1
High Capacity: Yes
Capacity: 7.3 GiB
Bus Width: 4-bit
Erase Group Size: 512 KiB
HC WP Group Size: 8 MiB
User Capacity: 7.3 GiB WRREL
Boot Capacity: 4 MiB ENH
RPMB Capacity: 512 KiB ENH
Boot area 0 is not write protected
Boot area 1 is not write protected
sp7#