### PR TITLE
board: Change erase block size to 4k

### DIFF
--- a/board/aspeed/evb_ast2700/evb_ast2700.c
+++ b/board/aspeed/evb_ast2700/evb_ast2700.c
@@ -478,6 +478,9 @@ void configure_edaf_spi(const u8 *eeprom_buf)
 		/* Set eSPI strap to high for IO/Alert pin mode */
 		run_command("gpio set 10", 0); //eSPI0
 		run_command("gpio set 11", 0); //eSPI1
+		/* Set Erase block size - underlying SPI uses 4K blocks */
+		run_command("mw 14c05028 401", 0); // eSPI0
+		run_command("mw 14c06028 401", 0); // eSPI1
 		printf("configuring for eDAF ...Done\n");
 	}
 	else {


### PR DESCRIPTION
change supported erase block size to 4k.
underlying spi supports only 4k erases.

Tested: Verified in Qemu
