### PR TITLE
board: remove 2nd LTPI from SP* PRB

### DIFF
--- a/board/aspeed/evb_ast2700/evb_ast2700.c
+++ b/board/aspeed/evb_ast2700/evb_ast2700.c
@@ -166,10 +166,10 @@ const BoardInfo boards[] = {
 	{ "marrakesh",  0xB0,   AMD_TYPE_SLT_1P,    ONE_LINK },
 	{ "falcon",     0xB1,   HCC_TYPE_1,         ONE_LINK },
 	{ "falcon",     0xB2,   HCC_TYPE_1,         ONE_LINK },
-	{ "falcon",     0xB3,   HCC_TYPE_1,         TWO_LINK },
+	{ "falcon",     0xB3,   HCC_TYPE_1,         ONE_LINK },
 	{ "falcon",     0xB4,   HCC_TYPE_1,         TWO_LINK },
-	{ "seagull",    0xB5,   HCC_TYPE_2,         TWO_LINK },
-	{ "seagull",    0xB6,   HCC_TYPE_2,         TWO_LINK },
+	{ "seagull",    0xB5,   HCC_TYPE_2,         ONE_LINK },
+	{ "seagull",    0xB6,   HCC_TYPE_2,         ONE_LINK },
 	{ "seagull",    0xB7,   HCC_TYPE_2,         TWO_LINK },
 };
 


### PR DESCRIPTION
SP8 PRB FPGA does not handle the 2nd LTPI line.
Remove it from YBOOT till problem get fixed

Tested:
- verified in SP8 Falcon and Seagull

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
