### PR TITLE
board: aspeed: 2700: enable power sequencing only on AC power cycle

### DIFF
--- a/board/aspeed/evb_ast2700/evb_ast2700.c
+++ b/board/aspeed/evb_ast2700/evb_ast2700.c
@@ -603,8 +603,16 @@ void power_on_hpm(int retry)
 	int hpm_en_gpio = HPM_EN_GPIO_REV_A;
 	int hpm_rdy_gpio = HPM_RDY_GPIO_REV_A;
 	const char *env_val = env_get("EN_HPM_PWR_SEQ");
+	const char *por_rst_env = env_get("por_rst");
 	bool env_enabled = (env_val && !strcmp(env_val, "1"));
 	bool rev_b = is_scm_rev_b();
+	bool ac_cycle_boot = (por_rst_env && !strcmp(por_rst_env, "true"));
+
+	if (!ac_cycle_boot) {
+		printf("Skipping HPM power sequence: non-AC-cycle boot (por_rst=%s)\n",
+		       por_rst_env ? por_rst_env : "unset");
+		return;
+	}
 
 	if (rev_b) {
 		hpm_rst_gpio = HPM_RST_GPIO_REV_B;


### PR DESCRIPTION
HPM power sequencing should be performed only during a cold boot (AC power cycle).

BMC reboot events must not trigger power sequencing again, as doing so can disrupt the current host power state.


